### PR TITLE
feat: add merged schema view tab

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,7 @@ const postcss = require('rollup-plugin-postcss')
 
 //using .js and not .mjs, due to importing json in mjs is still experimental
 const packageJson = require('./package.json')
-// globals: { react: 'React' },
+
 //
 const rollup = [
   {
@@ -26,10 +26,15 @@ const rollup = [
         file: packageJson.umd,
         format: 'umd',
         sourcemap: true,
-        name: 'federationInfo'
+        name: 'federationInfo',
+        globals: {
+          react: 'React',
+          '@graphiql/react': 'GraphiQL.React',
+          graphql: 'GraphiQL.GraphQL'
+        }
       }
     ],
-    external: ['react'],
+    external: ['react', '@graphiql/react', 'graphql'],
     plugins: [
       resolve({
         extensions: ['.js', '.jsx']

--- a/src/federation-info-plugin/components/Tabs/Tabs.jsx
+++ b/src/federation-info-plugin/components/Tabs/Tabs.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import joinClassNames from '../../utils/joinClassNames'
+import styles from './Tabs.module.scss'
+import { UnStyledButton } from '@graphiql/react'
+
+export const TabGroup = ({ className, ...props }) => (
+  <div className={joinClassNames(styles.tabGroup, className)} {...props} />
+)
+export const TabButton = ({ className, isActive, ...props }) => (
+  <UnStyledButton
+    className={joinClassNames(
+      styles.tabButton,
+      isActive && styles.tabActive,
+      className
+    )}
+    {...props}
+  />
+)

--- a/src/federation-info-plugin/components/Tabs/Tabs.module.scss
+++ b/src/federation-info-plugin/components/Tabs/Tabs.module.scss
@@ -1,0 +1,15 @@
+.tabGroup {
+    margin-left: calc(var(--px-4)*-1);
+    display: flex;
+    margin-top: var(--px-8);
+}
+
+.tabGroup > .tabButton {
+    padding: var(--px-4) var(--px-8);
+    margin-right: var(--px-4);
+}
+
+.tabGroup > .tabActive {
+    background-color: hsla(var(--color-neutral),var(--alpha-background-heavy));
+    color: hsla(var(--color-neutral),1);
+}

--- a/src/federation-info-plugin/lib/constants.js
+++ b/src/federation-info-plugin/lib/constants.js
@@ -11,6 +11,7 @@ export const TYPE_KIND = {
 }
 
 // introspectionTypes from GraphQL-JS repo: /src/type/introspection.ts
+// could use import { introspectionTypes } from 'graphql'
 export const INTROSPECTION_TYPES = [
   '__Schema',
   '__Directive',
@@ -28,3 +29,20 @@ export const SCALAR_TYPES = ['String', 'Int', 'Float', 'Boolean', 'ID']
 // Observed from examples
 export const GRAPH_QL_QUERY_NAMES = ['_entities', '_service']
 export const GRAPH_QL_OBJECT_NAMES = ['_Service']
+
+// https://github.com/mercurius-js/mercurius/blob/57ff23ab97c8dec1b2f6fa0f6d0439b22cdb9377/lib/federation.js#L46 //_Any and _FieldSet
+// https://github.com/mercurius-js/mercurius/blob/57ff23ab97c8dec1b2f6fa0f6d0439b22cdb9377/lib/federation.js#L174 //_Entity
+// https://github.com/mercurius-js/mercurius/blob/57ff23ab97c8dec1b2f6fa0f6d0439b22cdb9377/lib/federation.js#L56 // _Service
+export const BASE_FEDERATION_SCALARS = [
+  '_Any',
+  '_FieldSet',
+  '_Entity',
+  '_Service'
+]
+
+//rollup needs upgrading to support spread it seems
+export const IGNORED_TYPES = INTROSPECTION_TYPES.concat(
+  BASE_FEDERATION_SCALARS
+).concat(SCALAR_TYPES)
+
+export const IGNORED_FIELDS = [...GRAPH_QL_QUERY_NAMES]

--- a/src/federation-info-plugin/lib/prepareSchemaViewData.js
+++ b/src/federation-info-plugin/lib/prepareSchemaViewData.js
@@ -1,0 +1,141 @@
+import { TYPE_KIND, IGNORED_FIELDS, IGNORED_TYPES } from './constants'
+
+/**
+ * Extracts types or fields (depending if nodeFractions is list of types or list of nodes) from the list of nodes
+ *
+ * @param {string} name
+ * @param {*} nodesFractions
+ * @returns
+ */
+const fromNodes = (name, nodesFractions) => {
+  return nodesFractions
+    .map(nodeFraction => nodeFraction.itemsMap[name])
+    .filter(i => !!i)
+}
+
+const indexNodeFields = (nodeFields, nodeName) => {
+  return nodeFields.reduce((result, field) => {
+    if (!IGNORED_FIELDS.includes(field.name)) {
+      field.nodeName = nodeName
+      result[field.name] = field
+    }
+    return result
+  }, {})
+}
+
+/**
+ * Tranforms the object returned fromt the server into an array of objects that is easy to extract owner/reference information, without excessive iteration.
+ * Ideally should replace `parseFederationSchema`
+ *
+ * @param {{[string]: { __schema: import('graphql').IntrospectionQuery } }} federationSchema example: { "node1": {__schema: IntrospectionQuery }}
+ * @returns Object that is used to retrieve referencedBy and Owner
+ * @example
+ * ```
+ * [
+ * {
+ *      nodeName:'node1',
+ *      itemsMap: {
+ *          User: {
+ *              nodeName:'node1',
+ *              itemsMap: {
+ *                  id: {
+ *                      nodeName:'node1'
+ *                      },
+ *                  ...rest of the field props
+ *                  },
+ *              ...rest of the type props
+ *              },
+ *          ...rest of the node props
+ *      }
+ * }
+ * ]
+ *```
+ */
+const prepareNodesSchema = federationSchema => {
+  const nodesEntries = Object.entries(federationSchema.nodes)
+  return nodesEntries.map(([nodeName, { __schema }]) => {
+    const { types } = __schema
+    const itemsMap = types.reduce((result, current) => {
+      if (!IGNORED_TYPES.includes(current.name)) {
+        let itemsMap = {}
+        if (current.kind === TYPE_KIND.OBJECT) {
+          itemsMap = indexNodeFields(current.fields, nodeName)
+        } else if (current.kind === TYPE_KIND.INPUT_OBJECT) {
+          itemsMap = indexNodeFields(current.inputFields, nodeName)
+        }
+
+        result[current.name] = { ...current, itemsMap, nodeName }
+      }
+      return result
+    }, {})
+
+    return { nodeName, itemsMap }
+  })
+}
+
+/**
+ * Prepares the main schema (of type GraphQLSchema) so it can easily be rendered
+ *
+ * @param {{[string]: { __schema: import('graphql').IntrospectionQuery } }} federationSchema
+ * @param {import('graphql').GraphQLSchema} schema
+ *
+ * @returns see example
+ * @example
+ * ```
+ * [
+ *  {
+ *      name: "User"
+ *      ownerNodes: ["node1"],
+ *      referecedBy: [{ nodeName: "node2", key: "id"}],
+ *      fields: [
+ *          {
+ *              name: "id",
+ *              ownerNodes: ["node1"],
+ *              referencedBy: ["node2"],
+ *              ...other fields properties
+ *          }
+ *      ],
+ *      ...other type properties
+ *  }
+ * ]
+ * ```
+ */
+export const prepareSchemaView = (federationSchema, schema) => {
+  // return empty object if either one of the arguments is falsy
+  if (!schema || !federationSchema) return {}
+
+  const nodes = prepareNodesSchema(federationSchema)
+
+  //transverse the merged GraphQLSchema and add referencedBy and owner properties to it
+  return Object.entries(schema.getTypeMap())
+    .filter(([name]) => !IGNORED_TYPES.includes(name))
+    .map(([typeName, type]) => {
+      const typesFromNodes = fromNodes(typeName, nodes)
+      const ownerNodes = typesFromNodes
+        .filter(({ isExtension }) => !isExtension)
+        .map(({ nodeName }) => nodeName)
+      const referecedBy = typesFromNodes
+        .filter(({ key }) => !!key)
+        .map(({ nodeName, key }) => ({
+          nodeName,
+          key
+        }))
+
+      let fields = []
+      if (type.getFields) {
+        fields = Object.values(type.getFields()).map(field => {
+          const fieldsFromNodes = fromNodes(field.name, typesFromNodes)
+          const ownerNodes = fieldsFromNodes
+            .filter(({ isExternal }) => !isExternal)
+            .map(({ nodeName }) => nodeName)
+          const referecedBy = fieldsFromNodes
+            .filter(({ isExternal }) => isExternal)
+            .map(({ nodeName }) => nodeName)
+
+          return { ...field, ownerNodes, referecedBy, fieldsFromNodes }
+        })
+      }
+
+      return { ...type, ownerNodes, referecedBy, fields }
+    })
+}

--- a/src/federation-info-plugin/utils/__tests__/joinClassNames.test.js
+++ b/src/federation-info-plugin/utils/__tests__/joinClassNames.test.js
@@ -1,0 +1,29 @@
+import addClassName from '../joinClassNames'
+
+describe('addClassName', () => {
+  it('first empty', () => {
+    expect(addClassName('', 'test')).toEqual('test')
+    expect(addClassName(null, 'test')).toEqual('test')
+    expect(addClassName(undefined, 'test')).toEqual('test')
+  })
+
+  it('second empty', () => {
+    expect(addClassName('test', '')).toEqual('test')
+    expect(addClassName('test', null)).toEqual('test')
+    expect(addClassName('test', undefined)).toEqual('test')
+  })
+
+  it('both empty', () => {
+    expect(addClassName('', '')).toEqual('')
+    expect(addClassName(null, null)).toEqual('')
+    expect(addClassName(undefined, undefined)).toEqual('')
+  })
+
+  it('both non-empty', () => {
+    expect(addClassName('test1', 'test2')).toEqual('test1 test2')
+  })
+
+  it('multiple classes', () => {
+    expect(addClassName('test1', 'test2', 'test3')).toEqual('test1 test2 test3')
+  })
+})

--- a/src/federation-info-plugin/utils/joinClassNames.js
+++ b/src/federation-info-plugin/utils/joinClassNames.js
@@ -1,0 +1,9 @@
+/**
+ *
+ * @param {...string} classNames classNames to join
+ * @returns {string} merged multiple classnames
+ */
+const addClassName = (...classNames) =>
+  classNames.filter(classNames => !!classNames).join(' ')
+
+export default addClassName

--- a/src/federation-info-plugin/views/NodesView.jsx
+++ b/src/federation-info-plugin/views/NodesView.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import FederationNode from '../components/FederationNode/FederationNode'
+
+const NodesView = ({ federationNodes }) => (
+  <div>
+    {federationNodes.map((federationNode, index) => (
+      <FederationNode key={index} federationNode={federationNode} />
+    ))}
+  </div>
+)
+
+export default NodesView

--- a/src/federation-info-plugin/views/SchemaView.jsx
+++ b/src/federation-info-plugin/views/SchemaView.jsx
@@ -20,7 +20,7 @@ const FieldRow = ({ field }) => {
 const TypeRow = ({ type }) => {
   const [expanded, setExpanded] = useState(true)
   return (
-    <div>
+    <>
       <tr onClick={() => setExpanded(!expanded)}>
         <td>{type.name}</td>
         <td>{type.ownerNodes.join(', ')}</td>
@@ -52,7 +52,7 @@ const TypeRow = ({ type }) => {
           </td>
         </tr>
       )}
-    </div>
+    </>
   )
 }
 
@@ -68,9 +68,11 @@ const SchemaView = ({ schemaViewData }) => {
             <th>Extended by</th>
           </tr>
         </thead>
-        {schemaViewData.map(type => (
-          <TypeRow key={type.name} type={type} />
-        ))}
+        <tbody>
+          {schemaViewData.map(type => (
+            <TypeRow key={type.name} type={type} />
+          ))}
+        </tbody>
       </table>
     </div>
   )

--- a/src/federation-info-plugin/views/SchemaView.jsx
+++ b/src/federation-info-plugin/views/SchemaView.jsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react'
+import styles from './SchemaView.module.scss'
+
+const FieldRow = ({ field }) => {
+  const input = field.args
+    ? field.args.map(({ type, name }) => `${name}: ${type.toString()}`)
+    : ''
+
+  return (
+    <tr key={field.name}>
+      <td>{field.name}</td>
+      <td>{input}</td>
+      <td>{field.type.toString()}</td>
+      <td>{field.ownerNodes.join(',')}</td>
+      <td>{field.referecedBy.join(',')}</td>
+    </tr>
+  )
+}
+
+const TypeRow = ({ type }) => {
+  const [expanded, setExpanded] = useState(true)
+  return (
+    <div>
+      <tr onClick={() => setExpanded(!expanded)}>
+        <td>{type.name}</td>
+        <td>{type.ownerNodes.join(', ')}</td>
+        <td>
+          {type.referecedBy
+            .map(({ nodeName, key }) => `${nodeName} @key(${key[0].value})`)
+            .join(<br />)}
+        </td>
+      </tr>
+      {type.fields.length > 0 && expanded && (
+        <tr>
+          <td colSpan={3} className={styles.attributes}>
+            <table width="100%">
+              <thead>
+                <tr>
+                  <th>Attribute name</th>
+                  <th>Input</th>
+                  <th>Type</th>
+                  <th>Owner node</th>
+                  <th>Referenced by</th>
+                </tr>
+              </thead>
+              <tbody>
+                {type.fields.map(field => (
+                  <FieldRow key={field.name} field={field} />
+                ))}
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      )}
+    </div>
+  )
+}
+
+const SchemaView = ({ schemaViewData }) => {
+  return (
+    <div className={styles.schemaView}>
+      <h2>Entities</h2>
+      <table className={styles.entityTable}>
+        <thead>
+          <tr>
+            <th>Entity</th>
+            <th>Defined By</th>
+            <th>Extended by</th>
+          </tr>
+        </thead>
+        {schemaViewData.map(type => (
+          <TypeRow key={type.name} type={type} />
+        ))}
+      </table>
+    </div>
+  )
+}
+
+export default SchemaView

--- a/src/federation-info-plugin/views/SchemaView.module.scss
+++ b/src/federation-info-plugin/views/SchemaView.module.scss
@@ -1,0 +1,37 @@
+.schemaView {
+  table {
+    width: 100%;
+    text-align: left;
+    border-spacing: 0;
+    border-collapse: collapse;
+    border-radius: 8px;
+
+    th,
+    td {
+      margin: 0;
+      padding: 0.5rem;
+      border: 1px solid hsla(var(--color-neutral), 0.4);
+    }
+  }
+}
+
+h2 {
+    padding-top: 0.5em;
+}
+
+.attributes {
+  padding-right: 0 !important;
+  padding-left: 2em !important;
+  border-right: none !important;
+  border-left: none !important;
+
+  table {
+    background-color: hsla(var(--color-tertiary), 0.03);
+  }
+  
+  thead th,
+  tr:nth-child(even) {
+    background: hsla(var(--color-neutral), var(--alpha-background-light));
+  }
+}
+


### PR DESCRIPTION
Adds a new tab to view the whole schema and see which type/field is coming from which node.

PS: Style is currently broken due to the issues with the build (not handling fragments). I can fix it using array return from the component, or we fix the tooling to support react fragmetns (see #22 )