### PR TITLE
chore: upgrade vite-plugin-svgr so we can bump to vite 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "react-dom": "^18.2.0",
         "sass": "^1.55.0",
         "vite": "^3.2.2",
-        "vite-plugin-svgr": "^2.2.2"
+        "vite-plugin-svgr": "^2.4.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -16128,16 +16128,16 @@
       }
     },
     "node_modules/vite-plugin-svgr": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/vite-plugin-svgr/-/vite-plugin-svgr-2.2.2.tgz",
-      "integrity": "sha512-u8Ac27uZmDHTVGawpAhvLMJMuzbGeZGhe61TGeHoRQLxVhmQfIYCefa0iLbjC0ui1zFo6XZnS8EkzPITCYp85g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-svgr/-/vite-plugin-svgr-2.4.0.tgz",
+      "integrity": "sha512-q+mJJol6ThvqkkJvvVFEndI4EaKIjSI0I3jNFgSoC9fXAz1M7kYTVUin8fhUsFojFDKZ9VHKtX6NXNaOLpbsHA==",
       "dev": true,
       "dependencies": {
-        "@rollup/pluginutils": "^5.0.0",
-        "@svgr/core": "^6.4.0"
+        "@rollup/pluginutils": "^5.0.2",
+        "@svgr/core": "^6.5.1"
       },
       "peerDependencies": {
-        "vite": "^2.6.0 || 3"
+        "vite": "^2.6.0 || 3 || 4"
       }
     },
     "node_modules/vscode-languageserver-types": {
@@ -28266,13 +28266,13 @@
       }
     },
     "vite-plugin-svgr": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/vite-plugin-svgr/-/vite-plugin-svgr-2.2.2.tgz",
-      "integrity": "sha512-u8Ac27uZmDHTVGawpAhvLMJMuzbGeZGhe61TGeHoRQLxVhmQfIYCefa0iLbjC0ui1zFo6XZnS8EkzPITCYp85g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-svgr/-/vite-plugin-svgr-2.4.0.tgz",
+      "integrity": "sha512-q+mJJol6ThvqkkJvvVFEndI4EaKIjSI0I3jNFgSoC9fXAz1M7kYTVUin8fhUsFojFDKZ9VHKtX6NXNaOLpbsHA==",
       "dev": true,
       "requires": {
-        "@rollup/pluginutils": "^5.0.0",
-        "@svgr/core": "^6.4.0"
+        "@rollup/pluginutils": "^5.0.2",
+        "@svgr/core": "^6.5.1"
       }
     },
     "vscode-languageserver-types": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "react-dom": "^18.2.0",
     "sass": "^1.55.0",
     "vite": "^3.2.2",
-    "vite-plugin-svgr": "^2.2.2"
+    "vite-plugin-svgr": "^2.4.0"
   },
   "jest": {
     "testEnvironment": "jsdom",


### PR DESCRIPTION
Upgrades `vite-plugin-svgr` to the latest version `2.4.0` so dependabot [PR](https://github.com/nearform/mercurius-federation-info-graphiql-plugin/pull/105) can bump Vite to the latest version.