### PR TITLE
fix: #117 nullcheck on root types

### DIFF
--- a/src/federation-info-plugin/FederationInfo/FederationInfo.jsx
+++ b/src/federation-info-plugin/FederationInfo/FederationInfo.jsx
@@ -26,9 +26,9 @@ const FederationInfoContent = ({ federationSchemaUrl }) => {
   useEffect(() => {
     if (schema && servicesViewData) {
       setRootTypes({
-        queries: schema.getQueryType().name,
-        mutations: schema.getMutationType().name,
-        subscriptions: schema.getSubscriptionType().name
+        queries: schema.getQueryType()?.name,
+        mutations: schema.getMutationType()?.name,
+        subscriptions: schema.getSubscriptionType()?.name
       })
       setSchemaViewData(prepareSchemaViewData(servicesViewData, schema))
     }


### PR DESCRIPTION
Fixes #117 

Added optional chaning (`.?`) to the root type getters in case when no service defines a field for a root type