### PR TITLE
feat: automatic expansion and collapse of services tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "@vitejs/plugin-react": "^3.0.0",
     "babel-jest": "^29.2.2",
     "cross-env": "^7.0.3",
-    "deepdash": "^5.3.9",
     "desm": "^1.3.0",
     "eslint": "^8.26.0",
     "eslint-config-airbnb": "^19.0.4",

--- a/src/federation-info-plugin/context/PluginState.jsx
+++ b/src/federation-info-plugin/context/PluginState.jsx
@@ -3,92 +3,101 @@ import useLocalStorage from 'react-use/lib/useLocalStorage'
 
 export const PluginStateContext = createContext()
 
-const LOCAL_STORAGE_KEY = 'mercuriusFederetionInfoGraphiqlPluginState'
+const LOCAL_STORAGE_PREFIX = 'mercuriusFederetionInfoGraphiqlPluginState'
 
 const isArrayOrReset = value => (Array.isArray(value) ? value : [])
 
 const initialState = {
   openServices: [],
   openServiceTreeNodes: [],
-  openSchemaTables: []
+  openSchemaTables: [],
+  searchServicesQuery: ''
 }
 
 export const PluginStateProvider = ({ children }) => {
-  const [value, setValue] = useLocalStorage(LOCAL_STORAGE_KEY, initialState)
+  const [openServices, persistServiceOpen] = useLocalStorage(
+    `${LOCAL_STORAGE_PREFIX}:openServices`,
+    initialState.openServices
+  )
+  const [openServiceTreeNodes, persistOpenServiceTreeNodes] = useLocalStorage(
+    `${LOCAL_STORAGE_PREFIX}:openServiceTreeNodes`,
+    initialState.openServiceTreeNodes
+  )
+  const [searchServicesQuery, persistServicesSearchQuery] = useLocalStorage(
+    `${LOCAL_STORAGE_PREFIX}:searchServicesQuery`,
+    initialState.searchServicesQuery
+  )
+  const [openSchemaTables, persistSchemaTableOpen] = useLocalStorage(
+    `${LOCAL_STORAGE_PREFIX}:openSchemaTables`,
+    initialState.openSchemaTables
+  )
 
   const setServiceOpen = serviceName => {
-    const existingOpenServices = isArrayOrReset(value.openServices)
+    const existingOpenServices = isArrayOrReset(openServices)
 
     const existingOpenServicesSet = new Set([
       ...existingOpenServices,
       serviceName
     ])
 
-    setValue({
-      ...value,
-      openServices: Array.from(existingOpenServicesSet)
-    })
+    persistServiceOpen(Array.from(existingOpenServicesSet))
   }
 
   const setServiceClosed = serviceName => {
-    const existingOpenServices = isArrayOrReset(value.openServices)
+    const existingOpenServices = isArrayOrReset(openServices)
     const existingOpenServicesSet = new Set([
       ...existingOpenServices,
       serviceName
     ])
 
     existingOpenServicesSet.delete(serviceName)
-    setValue({
-      ...value,
-      openServices: Array.from(existingOpenServicesSet)
-    })
+    persistServiceOpen(Array.from(existingOpenServicesSet))
   }
 
   const setTreeOpenState = ({ openServices, openServiceTreeNodes }) => {
-    setValue({
-      ...value,
-      openServices,
-      openServiceTreeNodes
-    })
+    persistServiceOpen(openServices)
+    persistOpenServiceTreeNodes(openServiceTreeNodes)
   }
 
   const setOpenServiceTreeNodes = nodeIds => {
-    setValue({
-      ...value,
-      openServiceTreeNodes: nodeIds
-    })
+    persistOpenServiceTreeNodes(nodeIds)
   }
 
   const setSchemaTableOpen = tableId => {
-    const existingOpenTables = isArrayOrReset(value.openSchemaTables)
+    const existingOpenTables = isArrayOrReset(openSchemaTables)
     const existingOpenTablesSet = new Set([...existingOpenTables, tableId])
 
-    setValue({ ...value, openSchemaTables: Array.from(existingOpenTablesSet) })
+    persistSchemaTableOpen(Array.from(existingOpenTablesSet))
   }
 
   const setSchemaTableClosed = tableId => {
-    const existingOpenTables = isArrayOrReset(value.openSchemaTables)
+    const existingOpenTables = isArrayOrReset(openSchemaTables)
     const existingOpenTablesSet = new Set([...existingOpenTables, tableId])
 
     existingOpenTablesSet.delete(tableId)
 
-    setValue({ ...value, openSchemaTables: Array.from(existingOpenTablesSet) })
+    persistSchemaTableOpen(Array.from(existingOpenTablesSet))
+  }
+
+  const setServicesSearchQuery = query => {
+    persistServicesSearchQuery(query)
   }
 
   // Manually set the values or use the initial state.
   // This avoids the case there is a previous, old, local state
   // that does not have some fields in it.
   const providerValue = {
-    openServices: value.openServices || initialState.openServices,
-    openServiceTreeNodes:
-      value.openServiceTreeNodes || initialState.openServiceTreeNodes,
-    openSchemaTables: value.openSchemaTables || initialState.openSchemaTables,
+    openServices,
+    openServiceTreeNodes,
+    openSchemaTables,
+    searchServicesQuery,
     setServiceOpen,
     setServiceClosed,
     setTreeOpenState,
     setOpenServiceTreeNodes,
     setSchemaTableOpen,
-    setSchemaTableClosed
+    setSchemaTableClosed,
+    setServicesSearchQuery
   }
 
   return (

--- a/src/federation-info-plugin/context/PluginState.jsx
+++ b/src/federation-info-plugin/context/PluginState.jsx
@@ -18,6 +18,7 @@ export const PluginStateProvider = ({ children }) => {
 
   const setServiceOpen = serviceName => {
     const existingOpenServices = isArrayOrReset(value.openServices)
+
     const existingOpenServicesSet = new Set([
       ...existingOpenServices,
       serviceName
@@ -37,10 +38,17 @@ export const PluginStateProvider = ({ children }) => {
     ])
 
     existingOpenServicesSet.delete(serviceName)
-
     setValue({
       ...value,
       openServices: Array.from(existingOpenServicesSet)
+    })
+  }
+
+  const setTreeOpenState = ({ openServices, openServiceTreeNodes }) => {
+    setValue({
+      ...value,
+      openServices,
+      openServiceTreeNodes
     })
   }
 
@@ -77,6 +85,7 @@ export const PluginStateProvider = ({ children }) => {
     openSchemaTables: value.openSchemaTables || initialState.openSchemaTables,
     setServiceOpen,
     setServiceClosed,
+    setTreeOpenState,
     setOpenServiceTreeNodes,
     setSchemaTableOpen,
     setSchemaTableClosed

--- a/src/federation-info-plugin/lib/useFederationInfoHook.js
+++ b/src/federation-info-plugin/lib/useFederationInfoHook.js
@@ -28,7 +28,6 @@ export default function useFederationInfo(federationSchemaUrl) {
         setServicesViewData(prepareServicesViewData(federationSchema))
         setFederationInfoFetching(false)
       } catch (e) {
-        console.log(e)
         setFetchFederationInfoError(e)
       }
     }

--- a/src/federation-info-plugin/views/ServicesView/ServicesView.jsx
+++ b/src/federation-info-plugin/views/ServicesView/ServicesView.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react'
+import React, { useMemo, useState, useEffect } from 'react'
 import { Box } from '@mui/material'
 
 import PanelTitle from '../../components/PanelTitle/PanelTitle'
@@ -6,6 +6,7 @@ import ServiceInfo from '../../components/ServiceInfo/ServiceInfo'
 import SearchServiceInput from '../../components/SearchServiceInput/SearchServiceInput'
 import filterServicesInfo from '../../utils/filterServicesInfo'
 import { useDebounce } from 'use-debounce'
+import { usePluginState } from '../../context/PluginState'
 /**
  *
  * @param {Object} props.federationServices result of prepareServicesViewData
@@ -14,11 +15,20 @@ import { useDebounce } from 'use-debounce'
 const ServicesView = ({ federationServices }) => {
   const [searchText, setSearchText] = useState('')
   const [debouncedSearchText] = useDebounce(searchText, 150)
+  const { setTreeOpenState } = usePluginState()
 
-  const filteredServices = useMemo(
+  const { filteredServices, treeOpenState } = useMemo(
     () => filterServicesInfo(federationServices, debouncedSearchText),
     [federationServices, debouncedSearchText]
   )
+
+  useEffect(() => {
+    if (searchText && treeOpenState) {
+      setTreeOpenState(treeOpenState)
+    }
+    // not including the setTreeOpenState, it should not trigger the hook
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [treeOpenState])
 
   const services = debouncedSearchText ? filteredServices : federationServices
 

--- a/src/federation-info-plugin/views/ServicesView/ServicesView.jsx
+++ b/src/federation-info-plugin/views/ServicesView/ServicesView.jsx
@@ -13,14 +13,22 @@ import { usePluginState } from '../../context/PluginState'
  * @returns {JSX.Element}
  */
 const ServicesView = ({ federationServices }) => {
-  const [searchText, setSearchText] = useState('')
+  const { setTreeOpenState, setServicesSearchQuery, searchServicesQuery } =
+    usePluginState()
+  const [searchText, setSearchText] = useState(searchServicesQuery)
   const [debouncedSearchText] = useDebounce(searchText, 150)
-  const { setTreeOpenState } = usePluginState()
 
-  const { filteredServices, treeOpenState } = useMemo(
-    () => filterServicesInfo(federationServices, debouncedSearchText),
-    [federationServices, debouncedSearchText]
-  )
+  const { filteredServices, treeOpenState } = useMemo(() => {
+    return filterServicesInfo(federationServices, debouncedSearchText)
+  }, [federationServices, debouncedSearchText])
+
+  useEffect(() => {
+    if (searchServicesQuery !== debouncedSearchText) {
+      setServicesSearchQuery(debouncedSearchText)
+    }
+    //not including the setServicesSearchQuery, should never change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedSearchText])
 
   useEffect(() => {
     if (searchText && treeOpenState) {


### PR DESCRIPTION
Fixes: #120

![firefox_rz2eJaj6lR](https://user-images.githubusercontent.com/14069265/208953737-9d39e043-bf60-454b-907d-14e9a06b78ec.gif)

Implements:
* Saving search input into localstorage (saves across page refresh or navigating to different plugin tabs)
* Implements automatic expansion and collapsing of service tree items based on search (see gif attached)
* Simplification of the search logic, no recursion.

Testing per usual using `npm run example`
